### PR TITLE
Update CoinChangeCombination2.java

### DIFF
--- a/Recursion-Backtracking/CoinChangeCombination2.java
+++ b/Recursion-Backtracking/CoinChangeCombination2.java
@@ -17,8 +17,6 @@ public class CoinChangeCombination2 {
             coinChange(i, coins, amtsf + coins[i], tamt, asf + coins[i] + "-");
         }
         
-        // no call
-        coinChange(idx + 1, coins, amtsf, tamt, asf);
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
The line of code that was causing the repetition of answers was: 
```java 
     // no call
     coinChange(idx + 1, coins, amtsf, tamt, asf);
 ```
Removing this caused the answers to only print once, replicating the desired output of the code. 
